### PR TITLE
Prevent spam approvals using channel topic

### DIFF
--- a/Events/Interactions/ButtonUse.ts
+++ b/Events/Interactions/ButtonUse.ts
@@ -44,12 +44,21 @@ export async function execute(interaction, client: DiscordClient) {
                 ephemeral: true
             })
         }
+        
+        if(interaction.channel.topic?.includes('Approved')) {
+            return interaction.reply({
+                content: `This application has already been approved!`,
+                ephemeral: true
+            })
+        }
 
         const usr = interaction.guild.members.cache.find(m => m.id === interaction.channel.topic);
         usr.roles.add(interaction.guild.roles.cache.find(r => r.id === client.config.guild.roles.rw))
         interaction.reply({
             content: `**🥳 Congrats <@${usr.user.id}>! You have been approved for the \`rw\` role!**`
         })
+        
+        interaction.channel.setTopic(`${interaction.channel.topic} - Approved`, `The user has been approved`)
         
         if(chan instanceof TextChannel) chan?.send({
             embeds: [new EmbedBuilder().setDescription(`**${interaction.member.user.tag} approved: ${interaction.channel.name}**`)]


### PR DESCRIPTION
This PR should prevent spam approvals by checking if the channel topic includes the words `Approved`, and responding with an error if it does, however if it does not it will continue with the process and add the keyword to the channel topic at the end.

**Requires testing**